### PR TITLE
Disable AOT compilation and bump dependencies

### DIFF
--- a/build/build.clj
+++ b/build/build.clj
@@ -1,5 +1,4 @@
 (ns build
-  (:refer-clojure :exclude [compile])
   (:require [clojure.tools.build.api :as b]
             [deps-deploy.deps-deploy :as dd]))
 
@@ -21,22 +20,12 @@
   [_opts]
   (b/delete {:path "target"}))
 
-(defn compile
-  [_opts]
-  (b/compile-clj {:basis basis
-                  :class-dir class-dir
-                  :src-dirs ["src"]
-                  :compile-opts {:direct-linking true}
-                  :bindings {#'clojure.core/*assert* false
-                             #'clojure.core/*warn-on-reflection* true}}))
-
 (defn jar
   "Build the JAR."
   [_opts]
   (clean nil)
   (b/copy-dir {:src-dirs ["src" "resources"]
                :target-dir class-dir})
-  (compile nil)
   (b/write-pom {:class-dir     class-dir
                 :lib           lib
                 :version       version

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,19 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.11.2"}
-        org.slf4j/slf4j-api {:mvn/version "2.0.12"}}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        org.slf4j/slf4j-api {:mvn/version "2.0.16"}}
  :aliases
- {:dev {:extra-deps {org.slf4j/slf4j-simple {:mvn/version "2.0.12"}}}
+ {:dev {:extra-deps {org.slf4j/slf4j-simple {:mvn/version "2.0.16"}}}
   ;; clj -T:build ...
   :build {:extra-paths ["build"]
           :deps {io.github.clojure/tools.build
-                 {:git/tag "v0.10.0", :git/sha "3a2c484"}
+                 {:git/tag "v0.10.5", :git/sha "2a21b7a"}
                  slipset/deps-deploy {:mvn/version "0.2.2"}}
           :ns-default build}
   ;; clj -M:lint
   :lint {:replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
          :main-opts    ["-m" "clj-kondo.main" "--parallel" "--lint" "src"]}
   ;; clj -T:cljfmt fix
-  :cljfmt {:deps {io.github.weavejester/cljfmt {:git/tag "0.12.0", :git/sha "434408f"}}
+  :cljfmt {:deps {io.github.weavejester/cljfmt {:git/tag "0.13.0", :git/sha "f0230c3"}}
            :ns-default cljfmt.tool}
   ;; clj -T:antq outdated
   :antq {:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}


### PR DESCRIPTION
Turns out that AOT compiling a library ties it to a particular Clojure version and transitively compiles all other included Clojure libs, especially when `:direct-linking` is on.